### PR TITLE
Redesign homepage with "Field Notes" editorial theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,310 +1,447 @@
-
 <!DOCTYPE html>
 <html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Minnesota NLP — University of Minnesota</title>
+    <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
+    <meta name="keywords" content="NLP,Minnesota,Natural Language Processing">
+    <meta name="description" content="Minnesota NLP is a human-centered research group at the University of Minnesota developing language technologies that support expert work in law, science, education, and journalism.">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="icon" type="image/png" href="img/UMN_NLP_logo_final_circle.png" alt="Minnesota NLP logo"/>
 
-    <head>
-        <title>Minnesota NLP - University of Minnesota</title>
-        <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
-        <meta name="keywords" content="NLP,Minnesota,Natural Language Processing">
-        <meta name="description" content="Minnesota NLP is a research group at the University of Minnesota developing human-centered language technologies.">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <link rel="icon" type="image/png" href="img/UMN_NLP_logo_final_circle.png" alt="Minnesota NLP logo"/>
-    
-        <!-- WEBFONT -->
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    
-        <!-- SCRIPTS -->
-        <!-- <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script> -->
-        <script src="https://code.jquery.com/jquery-3.7.0.js" integrity="sha256-JlqSTELeR4TLqP0OG9dxM7yDPqX1ox/HfgiSLBj8+kM="   crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
-        <script  type="text/javascript" src="js/pub_loader.js"></script>
-        <script  type="text/javascript" src="js/member_loader.js"></script>
-        <script  type="text/javascript" src="js/news_loader.js"></script>
-        <script  type="text/javascript" src="js/alumni_search.js"></script>
-        <script  type="text/javascript" src="js/smooth_scroll.js"></script>
-        <script type="text/javascript" src="js/gh-profile-card.min.js"></script>
+    <!-- WEBFONTS -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500&display=swap" rel="stylesheet">
 
+    <!-- DATA LIBS (jQuery powers the live-data loaders) -->
+    <script src="https://code.jquery.com/jquery-3.7.0.js" integrity="sha256-JlqSTELeR4TLqP0OG9dxM7yDPqX1ox/HfgiSLBj8+kM=" crossorigin="anonymous"></script>
 
-        <!-- STYLE -->
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
-        <link rel="stylesheet" type="text/css" href="css/mystyle.css">
-        <link rel="stylesheet" type="text/css" href="css/slider.css">
+<style>
+:root{
+  --cream:#F5ECDF; --cream-2:#FBF4E9; --card:#FCF7EE; --espresso:#2B2018; --brown:#574436;
+  --mute:#8A7765; --line:#E3D6C3; --line-2:#D6C5AE;
+  --clay:#BC5630; --clay-deep:#9C4423; --olive:#6E7150; --sky:#3E6B6E;
+  --serif:'Spectral',Georgia,serif;
+}
+*{box-sizing:border-box;}
+html{scroll-behavior:smooth;}
+body{margin:0;background:var(--cream);color:var(--espresso);font-family:var(--serif);font-size:19px;line-height:1.62;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}
+a{color:inherit;}
+img{max-width:100%;}
+.wrap{max-width:1180px;margin:0 auto;padding:0 44px;}
+.eyebrow{font-size:13px;letter-spacing:.22em;text-transform:uppercase;color:var(--clay);font-weight:500;}
+.label{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:var(--mute);font-weight:500;}
+.skip-to-main{position:absolute;left:-9999px;top:0;background:var(--clay);color:#fff;padding:10px 18px;border-radius:0 0 8px 0;z-index:100;}
+.skip-to-main:focus{left:0;}
 
-    </head>
+/* nav */
+header.site{position:sticky;top:0;z-index:30;background:rgba(245,236,223,.9);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);}
+header.site .wrap{display:flex;align-items:center;justify-content:space-between;height:70px;}
+.brand{font-size:23px;font-weight:600;letter-spacing:.01em;text-decoration:none;color:var(--espresso);display:flex;align-items:center;gap:11px;white-space:nowrap;flex-shrink:0;}
+.brand .mk{width:34px;height:34px;border-radius:50%;overflow:hidden;background:var(--clay);display:inline-flex;align-items:center;justify-content:center;}
+.brand .mk img{width:100%;height:100%;object-fit:cover;display:block;}
+.nlinks{display:flex;align-items:center;gap:28px;}
+.nlinks a{font-size:14px;letter-spacing:.07em;text-transform:uppercase;text-decoration:none;color:var(--brown);font-weight:500;}
+.nlinks a:hover{color:var(--clay);}
+.nlinks .pill{border:1px solid var(--clay);color:var(--clay);border-radius:30px;padding:7px 18px;}
+.nlinks .pill:hover{background:var(--clay);color:#fff;}
+.nav-toggle{display:none;background:none;border:0;font-size:26px;color:var(--espresso);cursor:pointer;line-height:1;}
 
+/* hero */
+.hero{padding:58px 0 26px;}
+.hero-grid{display:grid;grid-template-columns:minmax(0,1.02fr) minmax(0,.98fr);gap:54px;align-items:start;}
+.hero .col-l{min-width:0;}
+.hero h1{font-size:clamp(36px,4.6vw,56px);line-height:1.12;font-weight:600;letter-spacing:-.01em;margin:16px 0 0;}
+.hero .hero-accent{font-size:clamp(30px,4vw,46px);line-height:1.14;font-style:italic;font-weight:400;color:var(--clay);margin:8px 0 0;}
+.hero .dek{font-size:21px;color:var(--brown);margin-top:26px;max-width:38ch;}
+.hero .dek b{color:var(--espresso);font-weight:600;}
+.hero .leads{margin-top:18px;font-style:italic;color:var(--mute);font-size:17px;}
+.hero .leads a{color:var(--clay);text-decoration:none;font-style:normal;font-weight:500;border-bottom:1px solid var(--line-2);}
+.hero .cta{display:flex;gap:14px;margin-top:30px;flex-wrap:wrap;}
+.btn{font-size:15px;font-weight:500;letter-spacing:.02em;text-decoration:none;padding:12px 24px;border-radius:30px;display:inline-block;}
+.btn.solid{background:var(--clay);color:#fff;}
+.btn.solid:hover{background:var(--clay-deep);}
+.btn.ghost{border:1px solid var(--line-2);color:var(--espresso);}
+.btn.ghost:hover{border-color:var(--clay);color:var(--clay);}
+.hero-photo{position:relative;}
+.hero-photo .frame{position:relative;border-radius:18px;overflow:hidden;aspect-ratio:5/6;background:#ddd2c0;box-shadow:0 26px 50px -22px rgba(60,38,20,.45);transform:rotate(1.4deg);}
+.hero-photo .frame img{width:100%;height:100%;object-fit:cover;display:block;transition:opacity .5s;}
+.hero-photo .tab{position:absolute;left:-14px;bottom:26px;background:var(--card);padding:11px 18px;border-radius:12px;box-shadow:0 10px 24px -10px rgba(60,38,20,.4);transform:rotate(-2deg);max-width:230px;}
+.hero-photo .tab .label{display:block;margin-bottom:2px;color:var(--clay);}
+.hero-photo .tab .cap{font-style:italic;font-size:15px;line-height:1.3;color:var(--brown);}
+.hero-photo .stamp{position:absolute;right:-8px;top:-12px;width:88px;height:88px;border-radius:50%;background:var(--olive);color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;transform:rotate(8deg);box-shadow:0 8px 20px -8px rgba(60,38,20,.5);}
+.hero-photo .stamp b{font-size:22px;font-weight:600;line-height:1;}
+.hero-photo .stamp span{font-size:9px;letter-spacing:.14em;text-transform:uppercase;margin-top:3px;}
+
+/* marquee strip */
+.strip{margin-top:36px;border-top:1px solid var(--line);border-bottom:1px solid var(--line);padding:16px 0;overflow:hidden;}
+.strip .wrap{display:flex;align-items:center;gap:34px;flex-wrap:wrap;justify-content:center;}
+.strip .label{color:var(--mute);}
+.strip .dom{font-size:24px;font-style:italic;color:var(--espresso);}
+.strip .dot{width:6px;height:6px;border-radius:50%;background:var(--clay);display:inline-block;}
+
+/* section */
+section{padding:66px 0;}
+.shead{margin-bottom:38px;max-width:720px;}
+.shead h2{font-size:clamp(30px,3.6vw,42px);font-weight:600;letter-spacing:-.01em;margin:10px 0 0;}
+.shead p{color:var(--brown);font-size:19px;margin:10px 0 0;}
+
+/* research cards */
+.tcards{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;}
+.tcard{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:26px 24px;transition:transform .25s,box-shadow .25s;}
+.tcard:hover{transform:translateY(-4px);box-shadow:0 18px 36px -20px rgba(60,38,20,.4);}
+.tcard .tn{font-size:15px;font-style:italic;color:var(--clay);}
+.tcard h3{font-size:24px;font-weight:600;margin:6px 0 8px;}
+.tcard p{margin:0;color:var(--brown);font-size:16.5px;line-height:1.5;}
+.tcard:nth-child(4) .tn,.tcard:nth-child(5) .tn{color:var(--olive);}
+
+/* people */
+.psec{background:var(--cream-2);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
+.pgroup{margin-bottom:42px;}
+.pgroup .ghead{display:flex;align-items:baseline;gap:14px;margin-bottom:22px;}
+.pgroup .ghead .label{color:var(--clay);}
+.pgroup .ghead .ln{flex:1;border-bottom:1px solid var(--line);transform:translateY(-4px);}
+.pgrid{display:grid;grid-template-columns:repeat(5,1fr);gap:24px;}
+.pc{text-align:left;}
+.pc a.shot{display:block;text-decoration:none;}
+.pc .ph{position:relative;display:block;aspect-ratio:4/5;border-radius:14px;overflow:hidden;background:var(--olive);box-shadow:0 12px 24px -16px rgba(60,38,20,.5);}
+.pc .ph img{width:100%;height:100%;object-fit:cover;transition:transform .5s;}
+.pc:hover .ph img{transform:scale(1.05);}
+.pc .ph .ini{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#e9e3d2;font-size:30px;font-style:italic;}
+.pc .nm{font-size:18px;font-weight:600;margin-top:12px;line-height:1.2;}
+.pc .nm a{text-decoration:none;color:var(--espresso);}
+.pc .nm a:hover{color:var(--clay);}
+.pc .rl{font-size:14px;letter-spacing:.03em;text-transform:uppercase;color:var(--mute);margin-top:3px;}
+.pc .rl a{color:var(--mute);text-decoration:none;border-bottom:1px solid var(--line-2);}
+.pc .rl a:hover{color:var(--clay);}
+.pc .it{font-size:15px;font-style:italic;color:var(--brown);margin-top:5px;line-height:1.35;}
+.pc .tg{display:inline-block;margin-top:7px;font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--clay);background:#F6E3D8;padding:3px 9px;border-radius:20px;}
+
+/* alumni */
+.afeat{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-bottom:30px;}
+.af{display:grid;grid-template-columns:78px 1fr;gap:18px;align-items:center;background:var(--card);border:1px solid var(--line);border-radius:16px;padding:18px 20px;}
+.af .ph{width:78px;height:78px;border-radius:50%;overflow:hidden;background:var(--olive);position:relative;flex-shrink:0;}
+.af .ph img{width:100%;height:100%;object-fit:cover;}
+.af .ph .ini{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#e9e3d2;font-size:24px;font-style:italic;}
+.af .nm{font-size:19px;font-weight:600;}
+.af .nm a{text-decoration:none;color:var(--espresso);}
+.af .nm a:hover{color:var(--clay);}
+.af .nx{color:var(--clay);font-style:italic;font-size:15px;margin:2px 0 5px;}
+.af .nt{font-size:14.5px;color:var(--brown);line-height:1.4;}
+.alist{display:grid;grid-template-columns:repeat(3,1fr);gap:8px 30px;}
+.acell{padding:10px 0;border-bottom:1px solid var(--line);font-size:16px;}
+.acell a{text-decoration:none;color:var(--espresso);border-bottom:1px solid var(--line-2);}
+.acell a:hover{color:var(--clay);}
+.acell .nx{font-style:italic;color:var(--mute);font-size:14px;}
+
+/* gallery */
+.gal{display:grid;grid-template-columns:2fr 1fr 1fr;grid-template-rows:180px 180px;gap:14px;}
+.gtile{position:relative;border-radius:14px;overflow:hidden;background:#ddd2c0;margin:0;}
+.gtile:first-child{grid-row:1/3;}
+.gtile img{width:100%;height:100%;object-fit:cover;transition:transform .6s;}
+.gtile:hover img{transform:scale(1.05);}
+.gtile figcaption{position:absolute;left:0;right:0;bottom:0;padding:24px 14px 10px;background:linear-gradient(transparent,rgba(43,32,24,.72));color:#fff;font-style:italic;font-size:14px;}
+
+/* publications */
+.pblock{display:grid;grid-template-columns:110px 1fr;gap:0;border-top:1px solid var(--line-2);}
+.pyr{font-size:30px;font-weight:600;color:var(--clay);padding:22px 0;position:sticky;top:84px;align-self:start;}
+.pitems{padding:22px 0;}
+.pit{padding:16px 0;border-bottom:1px solid var(--line);}
+.pitems .pit:last-child{border-bottom:0;}
+.pit .t{font-size:19px;line-height:1.32;font-weight:500;}
+.pit .t a{text-decoration:none;color:var(--espresso);background-image:linear-gradient(var(--clay),var(--clay));background-size:0 1.5px;background-repeat:no-repeat;background-position:0 100%;transition:background-size .3s;}
+.pit .t a:hover{background-size:100% 1.5px;color:var(--clay);}
+.pit .a{font-size:14.5px;color:var(--mute);margin-top:4px;}
+.pit .v{margin-top:6px;font-size:14px;}
+.pit .v em,.pit .v .venue a{font-style:italic;color:var(--clay);text-decoration:none;}
+.pit .v .highlight{font-style:italic;}
+.pit .nt{display:inline-block;margin-left:8px;font-size:11px;letter-spacing:.04em;text-transform:uppercase;color:var(--olive);border:1px solid #C7C7A6;border-radius:20px;padding:2px 9px;}
+.pit .tag a{color:var(--brown);text-decoration:none;border-bottom:1px solid var(--line-2);}
+.pit .tag a:hover{color:var(--clay);}
+.pall{margin-top:26px;font-style:italic;font-size:17px;}
+.pall a{color:var(--clay);}
+
+/* news */
+.nlist{max-width:860px;}
+.news-container{display:contents;}
+.nit,.news-card{display:grid;grid-template-columns:118px 1fr;gap:22px;padding:20px 0;border-top:1px solid var(--line);align-items:start;}
+.nit:first-child,.news-card:first-child{border-top:0;}
+.news-header{display:flex;flex-direction:column;gap:6px;}
+.news-date{font-size:14px;letter-spacing:.06em;text-transform:uppercase;color:var(--mute);}
+.news-badge{display:inline-block;width:fit-content;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:#fff;padding:2px 9px;border-radius:20px;font-weight:500;}
+.news-content{font-size:17px;line-height:1.5;}
+.news-content a{color:var(--espresso);text-decoration:none;border-bottom:1px solid var(--line-2);}
+.news-content a:hover{color:var(--clay);}
+.news-card-important .news-content{border-left:3px solid var(--clay);padding-left:14px;}
+
+/* funding */
+.fund-grid{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:30px 46px;}
+.sponsor-item{display:flex;align-items:center;justify-content:center;}
+.sponsor-link{display:flex;align-items:center;justify-content:center;}
+.sponsor-logo{max-height:48px;max-width:130px;width:auto;height:auto;object-fit:contain;filter:grayscale(1);opacity:.72;transition:filter .3s,opacity .3s;}
+.sponsor-link:hover .sponsor-logo{filter:grayscale(0);opacity:1;}
+.sponsor-logo-wide{max-width:160px;}
+.sponsor-logo-small{max-height:34px;}
+
+/* footer */
+footer.site{background:var(--espresso);color:#EDE2D3;}
+footer.site .wrap{padding:56px 44px 32px;}
+.ftop{display:grid;grid-template-columns:2fr 1fr 1fr;gap:40px;padding-bottom:34px;border-bottom:1px solid rgba(255,255,255,.14);}
+.fbrand{font-size:40px;font-weight:600;display:flex;align-items:center;gap:12px;}
+.fbrand .mk{width:40px;height:40px;border-radius:50%;overflow:hidden;background:var(--clay);display:inline-flex;align-items:center;justify-content:center;}
+.fbrand .mk img{width:100%;height:100%;object-fit:cover;}
+.ftop p{color:#C3B4A2;max-width:42ch;margin-top:14px;font-size:16px;}
+footer.site h4{font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--clay);margin:0 0 14px;font-weight:600;}
+footer.site ul{list-style:none;margin:0;padding:0;}
+footer.site li{margin-bottom:9px;}
+footer.site a{color:#EDE2D3;text-decoration:none;opacity:.85;font-size:16px;}
+footer.site a:hover{opacity:1;color:#fff;}
+.fbot{display:flex;justify-content:space-between;flex-wrap:wrap;gap:12px;padding-top:22px;font-size:13px;letter-spacing:.04em;color:#9A8B79;}
+
+/* back to top */
+#back-to-top{position:fixed;right:22px;bottom:22px;width:46px;height:46px;border-radius:50%;border:0;background:var(--clay);color:#fff;font-size:20px;cursor:pointer;opacity:0;pointer-events:none;transition:opacity .3s,transform .2s;box-shadow:0 8px 20px -8px rgba(60,38,20,.6);z-index:40;}
+#back-to-top.show{opacity:1;pointer-events:auto;}
+#back-to-top:hover{transform:translateY(-3px);background:var(--clay-deep);}
+
+@media(max-width:960px){
+  .wrap{padding:0 24px;}
+  .hero-grid{grid-template-columns:1fr;gap:40px;}
+  .hero-photo{max-width:440px;margin:0 auto;}
+  .tcards{grid-template-columns:1fr 1fr;}
+  .pgrid{grid-template-columns:repeat(3,1fr);}
+  .afeat,.gal{grid-template-columns:1fr;}
+  .gal{grid-template-rows:none;}
+  .gtile{height:200px;}
+  .gtile:first-child{grid-row:auto;}
+  .alist{grid-template-columns:1fr 1fr;}
+  .ftop{grid-template-columns:1fr;}
+  .pblock{grid-template-columns:66px 1fr;}
+  .pyr{font-size:24px;}
+}
+@media(max-width:640px){
+  .nav-toggle{display:block;}
+  .nlinks{position:absolute;top:70px;left:0;right:0;background:var(--cream-2);flex-direction:column;align-items:stretch;gap:0;padding:8px 24px 16px;border-bottom:1px solid var(--line);box-shadow:0 14px 24px -16px rgba(60,38,20,.5);display:none;}
+  .nlinks.open{display:flex;}
+  .nlinks a{padding:12px 4px;border-bottom:1px solid var(--line);}
+  .nlinks .pill{text-align:center;border-bottom:1px solid var(--clay);margin-top:8px;}
+  .pgrid{grid-template-columns:repeat(2,1fr);}
+  .tcards,.alist{grid-template-columns:1fr;}
+  .nit,.news-card{grid-template-columns:1fr;gap:6px;}
+  .news-header{flex-direction:row;align-items:center;gap:10px;}
+  .pit .t{font-size:18px;}
+}
+</style>
+</head>
 <body>
-    <a href="#main-content" class="skip-to-main">Skip to main content</a>
-    <div class="container-fluid" id="main-container" style="padding-left: 1.5rem; padding-right: 1.5rem;">
+<a href="#main-content" class="skip-to-main">Skip to main content</a>
 
-        <nav class="navbar navbar-expand-lg fixed-top justify-content-between navbar-custom" >
-            <div class="container-body-aligned">
-                <a class="navbar-brand navbar-brand-text" href="#">Minnesota NLP</a>
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
+<header class="site"><div class="wrap">
+  <a class="brand" href="#top"><span class="mk"><img src="img/UMN_NLP_logo_final_circle.png" alt="Minnesota NLP logo"></span>Minnesota NLP</a>
+  <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">☰</button>
+  <nav class="nlinks" id="navLinks">
+    <a href="#research">Research</a>
+    <a href="#people">People</a>
+    <a href="#life">Lab Life</a>
+    <a href="#publications">Papers</a>
+    <a href="#news">News</a>
+    <a href="https://dykang.github.io/project.html">Gallery</a>
+    <a class="pill" href="#people">Join us</a>
+  </nav>
+</div></header>
 
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav mr-auto">
-                        <li class="nav-item">
-                            <a class="nav-link" href="index.html">Home <span class="sr-only">(current)</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="https://dykang.github.io/project.html">Gallery</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="index.html#publication">Publication</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="index.html#people">People</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </nav>
+<a id="top"></a>
+<main id="main-content">
 
-         <div style="margin-bottom: 1.5rem;"></div>
+<section class="hero"><div class="wrap">
+  <div class="hero-grid">
+    <div class="col-l">
+      <span class="eyebrow">A human-centered NLP lab · University of Minnesota</span>
+      <h1>We teach machines to read &amp; write</h1>
+      <p class="hero-accent">— with people in mind.</p>
+      <p class="dek">We&rsquo;re an <b>interdisciplinary research group</b> drawing from linguistics, the social sciences, and cognitive science to build state-of-the-art AI that supports expert work in law, science, education, and journalism.</p>
+      <p class="leads">Led by <a href="https://dykang.github.io/">Dongyeop Kang</a> &amp; <a href="https://www.alexander-spangher.com/">Alexander Spangher</a> <span style="font-style:italic">(joining Fall 2026)</span> in <a href="https://cse.umn.edu/cs">Computer Science &amp; Engineering</a> at the <a href="https://twin-cities.umn.edu/">University of Minnesota — Twin Cities</a>.</p>
+      <div class="cta">
+        <a class="btn solid" href="#people">Meet the team</a>
+        <a class="btn ghost" href="#publications">Read our work</a>
+      </div>
+    </div>
+    <div class="hero-photo">
+      <div class="frame"><img id="heroImg" alt="Minnesota NLP group"></div>
+      <div class="stamp"><b>Est.</b><span>2021</span></div>
+      <div class="tab"><span class="label">From the lab</span><span class="cap" id="heroCap"></span></div>
+    </div>
+  </div>
+</div></section>
 
+<div class="strip"><div class="wrap">
+  <span class="label">We support experts in</span>
+  <span class="dom">Law</span> <span class="dot"></span>
+  <span class="dom">Science</span> <span class="dot"></span>
+  <span class="dom">Education</span> <span class="dot"></span>
+  <span class="dom">Journalism</span>
+</div></div>
 
-        <div class="row">
-            <!-- Left column: Main content (col-md-8) -->
-             <div class="col-1 col-order-left"></div>
-            <div class="col-7 col-order-main">
-                <div class="hero-banner">
-                    <div class="hero-banner-left">
-                        <img src="img/UMN_NLP_logo_final_circle.png" class="hero-logo-img" alt="Minnesota NLP Logo">
-                        <span class="hero-lab-label">Minnesota NLP</span>
-                    </div>
-                    <div class="hero-banner-right">
-                        <h1 class="hero-title">Welcome to Minnesota NLP</h1>
-                        <p class="hero-text">
-                            A research group led by <a href="https://dykang.github.io/">Dongyeop Kang</a> and <a href='https://www.alexander-spangher.com/'>Alexander Spangher</a> (joining Fall 2026) in <a href="https://cse.umn.edu/cs">Computer Science &amp; Engineering</a> at the <a href="https://twin-cities.umn.edu/">University of Minnesota – Twin Cities</a>.
-                            We are an inter-disciplinary team drawing from linguistics, social sciences, and cognitive sciences to develop state-of-the-art AI and support expert workflows in law, science, education, journalism, and beyond.
-                        </p>
-                        <div class="hero-badges">
-                            <span class="hero-badge"><i class="fa fa-university"></i> CS&amp;E · UMN</span>
-                            <span class="hero-badge"><i class="fa fa-users"></i> Interdisciplinary Research</span>
-                            <span class="hero-badge"><i class="fa fa-flask"></i> Human-Centered AI</span>
-                        </div>
-                    </div>
-                </div>
+<section id="research"><div class="wrap">
+  <div class="shead">
+    <span class="eyebrow">What we work on</span>
+    <h2>Five questions we keep returning to.</h2>
+    <p>Our research spans modeling and alignment through to cognition and the messy, expert workflows where language really matters.</p>
+  </div>
+  <div class="tcards">
+    <div class="tcard"><div class="tn">01 — Modeling</div><h3>Modeling</h3><p>Controllable generation, structure-aware tuning, and efficient adaptation of large language models.</p></div>
+    <div class="tcard"><div class="tn">02 — Alignment</div><h3>Alignment</h3><p>Reward learning, preference modeling, and calibrated abstention so systems know what they don&rsquo;t know.</p></div>
+    <div class="tcard"><div class="tn">03 — Evaluation</div><h3>Evaluation</h3><p>LLM-as-judge bias, cognitive benchmarks, and principled assessment of model behavior.</p></div>
+    <div class="tcard"><div class="tn">04 — Cognition</div><h3>Cognition</h3><p>Reading processes, executive function, and eye-tracking signals that connect language and the mind.</p></div>
+    <div class="tcard"><div class="tn">05 — Expert Workflows</div><h3>Expert Workflows</h3><p>Legal reasoning, scientific writing, and journalism support built alongside the people who do the work.</p></div>
+  </div>
+</div></section>
 
-                <!-- Slideshow container -->
-                <div class="slideshow-container">
-                    <!-- Full-width images with number and caption text -->
-                    <div class="mySlides fade">
-                        <img src="img/group/lab_picnic_april_2026.jpg" style="width:100%">
-                        <div class="slider_text">Lab picnic, April 2026</div>
-                    </div>
-                    <div class="mySlides fade">
-                        <img src="img/group/end-of-semester-2025-fall.jpg" style="width:100%">
-                        <div class="slider_text">End-of-semester gathering, 2025 Fall</div>
-                    </div>
-                    <div class="mySlides fade">
-                        <img src="img/group/reunion_at_colm.jpg" style="width:100%">
-                        <div class="slider_text">Reunion at CoLM</div>
-                    </div>
+<section id="people" class="psec"><div class="wrap">
+  <div class="shead">
+    <span class="eyebrow">The people</span>
+    <h2>An interdisciplinary team.</h2>
+    <p>Linguists, computer scientists, and cognitive scientists — advised by Dongyeop Kang, with Alexander Spangher joining in Fall 2026.</p>
+  </div>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/tea_house_20250509.jpg" style="width:100%">
-                        <div class="slider_text">Farewell lunch, May 9, 2025 </div>
-                    </div>       
+  <div class="pgroup">
+    <div class="ghead"><span class="label">Faculty</span><span class="ln"></span></div>
+    <div class="pgrid" id="members_faculty"></div>
+  </div>
+  <div class="pgroup">
+    <div class="ghead"><span class="label">Postdocs &amp; Visitors</span><span class="ln"></span></div>
+    <div class="pgrid" id="members_visitors"></div>
+  </div>
+  <div class="pgroup">
+    <div class="ghead"><span class="label">Ph.D. Students</span><span class="ln"></span></div>
+    <div class="pgrid" id="members_phd"></div>
+  </div>
+  <div class="pgroup">
+    <div class="ghead"><span class="label">Masters &amp; Undergraduate</span><span class="ln"></span></div>
+    <div class="pgrid" id="members_mastersundergraduate"></div>
+  </div>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/emnlp2024.jpeg" style="width:100%">
-                        <div class="slider_text">Shirley, Karin, and Ruyuan at EMNLP! Nov 12, 2024 </div>
-                    </div>                   
+  <div class="pgroup">
+    <div class="ghead"><span class="label">Doctoral alumni</span><span class="ln"></span></div>
+    <div class="afeat" id="members_alumni_phd"></div>
+    <div class="ghead"><span class="label">Masters &amp; undergraduate alumni</span><span class="ln"></span></div>
+    <div class="alist" id="members_alumni_mastersundergraduate"></div>
+  </div>
+</div></section>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/group_tennis.jpg" style="width:100%">
-                        <div class="slider_text">Tennis Drill! May 3, 2024 </div>
-                    </div>                  
+<section id="life"><div class="wrap">
+  <div class="shead">
+    <span class="eyebrow">Lab life</span>
+    <h2>We take the work seriously — not ourselves.</h2>
+    <p>Picnics, escape rooms, paper clinics, and the occasional tennis drill. A research group is a community first.</p>
+  </div>
+  <div class="gal">
+    <figure class="gtile"><img src="img/group/lab_picnic_april_2026.jpg" alt="Lab picnic" loading="lazy"><figcaption>Lab picnic — April 2026</figcaption></figure>
+    <figure class="gtile"><img src="img/group/end-of-semester-2025-fall.jpg" alt="End-of-semester gathering" loading="lazy"><figcaption>End-of-semester gathering — Fall 2025</figcaption></figure>
+    <figure class="gtile"><img src="img/group/reunion_at_colm.jpg" alt="Reunion at CoLM" loading="lazy"><figcaption>Reunion at CoLM</figcaption></figure>
+    <figure class="gtile"><img src="img/group/group_tennis.jpg" alt="Tennis drill" loading="lazy"><figcaption>Tennis drill — May 2024</figcaption></figure>
+    <figure class="gtile"><img src="img/group/escaperoom.jpg" alt="Lab escape room" loading="lazy"><figcaption>First lab escape room — Feb 2024</figcaption></figure>
+  </div>
+</div></section>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/escaperoom.jpg" style="width:100%">
-                        <div class="slider_text">Escape room! Feb 21, 2024 </div>
-                    </div>     
+<section id="publications" class="psec"><div class="wrap">
+  <div class="shead">
+    <span class="eyebrow">Selected papers</span>
+    <h2>Recent work.</h2>
+  </div>
+  <div id="publication">
+    <div id="publication_2026"></div>
+    <div id="publication_2025"></div>
+    <div id="publication_2024"></div>
+    <div id="publication_2023"></div>
+    <div id="publication_2022"></div>
+    <div id="publication_2021"></div>
+  </div>
+  <p class="pall">→ See the <a href="https://dykang.github.io/">complete publication list</a>.</p>
+</div></section>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/paper_clinic_11082023.png" style="width:100%">
-                        <div class="slider_text">NAACL paper clinic! Nov 2023 </div>
-                    </div>       	                
+<section id="news"><div class="wrap">
+  <div class="shead">
+    <span class="eyebrow">News &amp; notes</span>
+    <h2>What&rsquo;s happening lately.</h2>
+  </div>
+  <div class="nlist" id="items_news"></div>
+</div></section>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/bqq2.JPG" style="width:100%">
-                        <div class="slider_text">Korean BBQ Party with Soju+Beer, Sep 22, 2022</div>
-                    </div>
+<section id="funding" class="psec"><div class="wrap">
+  <div class="shead" style="text-align:center;margin:0 auto 38px;">
+    <span class="eyebrow">With support from</span>
+    <h2>Funding &amp; partners.</h2>
+  </div>
+  <div class="fund-grid" id="funding-logos"></div>
+</div></section>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/corn_maze.JPG" style="width:100%">
-                        <div class="slider_text">Corn Maze, Oct 29, 2022</div>
-                    </div>
+</main>
 
-                    <div class="mySlides fade">
-                        <img src="img/group/meetup.JPG" style="width:100%">
-                        <div class="slider_text">Meetup without DK! </div>
-                    </div>   
-                </div>
-                <!-- The dots/circles -->
-                <div style="text-align:center">
-                    <span class="dot"></span> 
-                    <span class="dot"></span> 
-                    <span class="dot"></span> 
-                    <span class="dot"></span> 
-                    <span class="dot"></span> 
-                    <span class="dot"></span>         
-                    <span class="dot"></span>                 
-                    <span class="dot"></span>                      
-                    <span class="dot"></span>                 
-               
-                    <span class="dot"></span>                 
-                    <span class="dot"></span>                 
-                </div>
+<footer class="site"><div class="wrap">
+  <div class="ftop">
+    <div>
+      <div class="fbrand"><span class="mk"><img src="img/UMN_NLP_logo_final_circle.png" alt="Minnesota NLP logo"></span>Minnesota NLP</div>
+      <p>We are an interdisciplinary research group developing human-centered language technologies. Drawing from linguistics, the social sciences, and cognitive science, we build state-of-the-art AI that supports expert workflows in law, science, education, and journalism.</p>
+    </div>
+    <div><h4>Explore</h4><ul>
+      <li><a href="#research">Research</a></li>
+      <li><a href="#people">People</a></li>
+      <li><a href="#publications">Papers</a></li>
+      <li><a href="https://dykang.github.io/project.html">Research Gallery</a></li>
+    </ul></div>
+    <div><h4>Find us</h4><ul>
+      <li><a href="https://github.com/minnesotanlp">GitHub</a></li>
+      <li><a href="https://huggingface.co/minnesotanlp">Hugging Face</a></li>
+      <li><a href="https://twitter.com/MinnesotaNLP">Twitter / X</a></li>
+      <li><a href="https://www.youtube.com/channel/UCtZN01zrrX4WYKRaoDt_rLA/playlists">YouTube</a></li>
+    </ul></div>
+  </div>
+  <div class="fbot">
+    <span>© 2026 Minnesota NLP · CS&amp;E · University of Minnesota — Twin Cities</span>
+    <span>Set in Spectral · Minneapolis, MN</span>
+  </div>
+</div></footer>
 
-                <div class="slideshow-social">
-                    <a href="https://www.youtube.com/channel/UCtZN01zrrX4WYKRaoDt_rLA/playlists" title="YouTube" aria-label="YouTube"><i class="fa fa-youtube-play"></i></a>
-                    <a href="https://github.com/minnesotanlp" title="GitHub" aria-label="GitHub"><i class="fa fa-github"></i></a>
-                    <a href="https://twitter.com/MinnesotaNLP" title="Twitter" aria-label="Twitter"><i class="fa fa-twitter"></i></a>
-                    <a href="https://huggingface.co/minnesotanlp" title="Hugging Face" aria-label="Hugging Face"><img src="img/hf-logo.png" alt="Hugging Face" style="width: 20px; height: 20px; vertical-align: middle;" /></a>
-                </div>
+<button id="back-to-top" title="Back to top" aria-label="Back to top">↑</button>
 
-                <main id="main-content">
-                    <div id="people">
-                        <div class="section-heading-center">
-                            <h2>People</h2>
-                        </div>
+<!-- Live-data loaders (render members, alumni, publications, news, sponsors from JSON) -->
+<script type="text/javascript" src="js/pub_loader.js"></script>
+<script type="text/javascript" src="js/member_loader.js"></script>
+<script type="text/javascript" src="js/news_loader.js"></script>
+<script type="text/javascript" src="js/sponsor_loader.js"></script>
+<script type="text/javascript" src="js/myscript_footer.js"></script>
 
-                        <!-- Faculty Row -->
-                        <div style="margin-bottom: 1.5rem;">
-                            <h4 class="section-title">Faculty</h4>
-                            <div style="display: flex; flex-wrap: wrap; justify-content: center;" id="members_faculty"></div>
-                        </div>
+<script>
+// Hero photo cycle (local group photos)
+(function(){
+  var photos=[
+    {src:'img/group/lab_picnic_april_2026.jpg',cap:'Lab picnic — April 2026'},
+    {src:'img/group/end-of-semester-2025-fall.jpg',cap:'End-of-semester gathering — Fall 2025'},
+    {src:'img/group/reunion_at_colm.jpg',cap:'Reunion at CoLM'},
+    {src:'img/group/tea_house_20250509.jpg',cap:'Farewell lunch — May 2025'},
+    {src:'img/group/group_tennis.jpg',cap:'Tennis drill — May 2024'},
+    {src:'img/group/escaperoom.jpg',cap:'First lab escape room — Feb 2024'}
+  ];
+  var img=document.getElementById('heroImg'), cap=document.getElementById('heroCap'), i=0;
+  function show(k){i=k;img.style.opacity=0;setTimeout(function(){img.src=photos[k].src;cap.textContent=photos[k].cap;img.style.opacity=1;},170);}
+  img.src=photos[0].src;cap.textContent=photos[0].cap;
+  setInterval(function(){show((i+1)%photos.length);},5400);
+})();
 
-                        <!-- Visitor Row -->
-                        <div style="margin-bottom: 1.5rem;">
-                            <h4 class="section-title">Postdocs & Visitors</h4>
-                            <div style="display: flex; flex-wrap: wrap; justify-content: center;" id="members_visitors"></div>
-                        </div>
-                        
-                        <!-- Ph.D. Students Row -->
-                        <div style="margin-bottom: 1.5rem;">
-                            <h4 class="section-title">Ph.D. Students</h4>
-                            <div style="display: flex; flex-wrap: wrap; justify-content: center;" id="members_phd"></div>
-                        </div>
+// Mobile nav
+(function(){
+  var t=document.getElementById('navToggle'), n=document.getElementById('navLinks');
+  t.addEventListener('click',function(){var o=n.classList.toggle('open');t.setAttribute('aria-expanded',o);});
+  n.addEventListener('click',function(e){if(e.target.tagName==='A')n.classList.remove('open');});
+})();
 
-                        <!-- Masters & Undergraduate Students Row -->
-                        <div style="margin-bottom: 1.5rem;">
-                            <h4 class="section-title">Masters and Undergraduate Students</h4>
-                            <div style="display: flex; flex-wrap: wrap; justify-content: center;" id="members_mastersundergraduate"></div>
-                        </div>
-
-                        <!-- Alumni Section -->
-                        <div style="margin-bottom: 2rem;">
-                            <h3 class="section-title">Alumni</h3>
-
-                            <!-- PhD Alumni -->
-                            <h5>Ph.D. Students and Visitors</h5>
-                            <div id="members_alumni_phd"></div>
-
-                            <!-- Masters & Undergraduate Alumni (combined, inline) -->
-                            <h5 class="mt-4">Masters and Undergraduate</h5>
-                            <div id="members_alumni_mastersundergraduate"></div>
-                        </div>
-
-                        <br>
-                        <div id="publication">
-                            <h2>Publications</h2>
-                            <div id="publication_2026"></div>
-                            <div id="publication_2025"></div>
-                            <div id="publication_2024"></div>
-                            <div id="publication_2023"></div>
-                            <div id="publication_2022"></div>
-                            <div id="publication_2021"></div>
-                        </div>
-
-                    </div>
-                </main>
-            </div>
-
-
-            <!-- Right column: News and Sponsors (col-1) -->
-            <div class="col-3 col-order-sidebar">
-                <h2 class="sidebar-section-heading">News</h2>
-                <div class="sidebar-card">
-                    <div id="items_news"></div>
-                </div>
-                <div id="funding">
-                    <h2 class="sidebar-section-heading">Funding</h2>
-                    <div id="funding-logos" style="display: flex; flex-direction: column; gap: 0.75rem; width: 100%;"></div>
-                </div>
-            </div>
-            <div class="col-1 col-order-right"></div>
-        </div>
-
-    <footer class="footer" role="contentinfo">
-        <div class="container-body-aligned">
-            <div class="footer-content">
-                <!-- Quick Links -->
-                <div class="footer-section">
-                    <h4>Quick Links</h4>
-                    <ul>
-                        <li><a href="index.html">Home</a></li>
-                        <li><a href="index.html#people">People</a></li>
-                        <li><a href="index.html#publication">Publications</a></li>
-                        <li><a href="https://dykang.github.io/project.html">Research Gallery</a></li>
-                    </ul>
-                </div>
-
-                <!-- Resources -->
-                <div class="footer-section">
-                    <h4>Resources</h4>
-                    <ul>
-                        <li><a href="https://cse.umn.edu/cs">Computer Science & Engineering</a></li>
-                        <li><a href="https://twin-cities.umn.edu/">University of Minnesota</a></li>
-                        <li><a href="https://huggingface.co/minnesotanlp">Hugging Face Models</a></li>
-                        <li><a href="https://github.com/minnesotanlp">GitHub Repository</a></li>
-                    </ul>
-                </div>
-
-                <!-- Contact & Social -->
-                <div class="footer-section">
-                    <h4>Connect With Us</h4>
-                    <div class="footer-social">
-                        <a href="https://github.com/minnesotanlp" title="GitHub" aria-label="GitHub">
-                            <i class="fa fa-github"></i>
-                        </a>
-                        <a href="https://twitter.com/MinnesotaNLP" title="Twitter" aria-label="Twitter">
-                            <i class="fa fa-twitter"></i>
-                        </a>
-                        <a href="https://huggingface.co/minnesotanlp" title="Hugging Face" aria-label="Hugging Face">
-                            <img src="img/hf-logo.png" alt="Hugging Face" style="width: 20px; height: 20px;">
-                        </a>
-                        <a href="https://www.youtube.com/channel/UCtZN01zrrX4WYKRaoDt_rLA/playlists" title="YouTube" aria-label="YouTube">
-                            <i class="fa fa-youtube-play"></i>
-                        </a>
-                    </div>
-                </div>
-            </div>
-
-            <div class="footer-bottom">
-                <p>© 2025 Minnesota NLP • <a href="https://cse.umn.edu/cs">Computer Science & Engineering</a> • <a href="https://twin-cities.umn.edu/">University of Minnesota - Twin Cities</a></p>
-                <p>Last updated February 2026</p>
-            </div>
-        </div>
-    </footer>
-
-    </div> <!-- /container -->
-
-    <!-- Back to Top Button -->
-    <button id="back-to-top" title="Back to top" aria-label="Back to top"><i class="fa fa-arrow-up"></i></button>
-
-    <script type="text/javascript" src="js/slider.js"></script>
-    <script type="text/javascript" src="js/myscript_footer.js"></script>
-    <script type="text/javascript" src="js/sponsor_loader.js"></script>
-    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
-    <script async type="text/javascript" src="js/widget.js"></script>
-
+// Back to top
+(function(){
+  var b=document.getElementById('back-to-top');
+  window.addEventListener('scroll',function(){b.classList.toggle('show',window.scrollY>500);});
+  b.addEventListener('click',function(){window.scrollTo({top:0,behavior:'smooth'});});
+})();
+</script>
 </body>
 </html>

--- a/js/member_loader.js
+++ b/js/member_loader.js
@@ -1,270 +1,188 @@
 
 function shuffleArray(array) {
-    for (var i = array.length - 1; i > 0; i--) { 
-   
-        // Generate random number 
+    for (var i = array.length - 1; i > 0; i--) {
         var j = Math.floor(Math.random() * (i + 1));
-                   
         var temp = array[i];
         array[i] = array[j];
         array[j] = temp;
     }
-       
     return array;
- }
+}
 
-function render_member(elements, filter=null){
+// Two-letter initials used as a graceful fallback when a photo is missing or fails to load.
+function member_initials(name) {
+    if (!name) return '';
+    return name.trim().split(/\s+/).map(function (w) { return w[0]; }).slice(0, 2).join('').toUpperCase();
+}
 
-    var decodedText = '';
-    var decodedTextList = [];
+// Photo block with an initials placeholder behind the image.
+// The placeholder shows until the image loads, and re-appears if the image errors.
+function member_photo(value, phClass) {
+    var ini = '<span class="ini">' + member_initials(value.name) + '</span>';
+    if (value.photo != null) {
+        return '<span class="' + phClass + '">' + ini +
+            '<img src="' + value.photo + '" alt="' + value.name + '" loading="lazy" ' +
+            'onload="this.previousElementSibling.style.display=\'none\'" ' +
+            'onerror="this.style.display=\'none\';this.previousElementSibling.style.display=\'flex\'"></span>';
+    }
+    return '<span class="' + phClass + '">' + ini + '</span>';
+}
 
+
+function render_member(elements, filter = null) {
+
+    var cards = [];
     var counter = 0;
-    // console.log(elements);
-
 
     $.each(elements, function (index, value) {
-        // decoder.html(value.title);
-        // console.log(value);
-        // decodedText += decoder.text();
-    //    console.log(value.name + ' / ' + value.position + ' : ' + filter + ' / ' + index + ' : ' + counter);
 
-        // filters
-        if (filter != null){
-            if (filter === 'current'){
-                if (value.current === false){
-                    // console.log('Pass');
-                        return;
-                }
+        // filters (preserve the live members.json position vocabulary)
+        if (filter != null) {
+            if (filter === 'current') {
+                if (value.current === false) { return; }
             }
-
-            if (filter === 'faculty'){
-                if (value.position != `Assistant Professor` && value.position != `Associate Professor` && value.position != `Professor`){
-                    // console.log('Pass');
-                        return;
-                }
+            if (filter === 'faculty') {
+                if (value.position != 'Assistant Professor' && value.position != 'Associate Professor' && value.position != 'Professor') { return; }
             }
-            if (filter === 'phd'){
-                if (value.position != `PhD` && value.position != `Visiting PhD`){
-                        return;
-                }
+            if (filter === 'phd') {
+                if (value.position != 'PhD' && value.position != 'Visiting PhD') { return; }
             }
-            if (filter === 'mastersundergraduate'){
-                if (value.position != `Masters` && value.position != `Undergraduate`){
-                        return;
-                }
+            if (filter === 'mastersundergraduate') {
+                if (value.position != 'Masters' && value.position != 'Undergraduate') { return; }
             }
-            if (filter === 'visitors'){
-                if (value.position != `Research Engineer` && value.position != `Postdoc` && value.position != `Visiting Scholar`){
-                        return;
-                }          
-            }                     
-            if (filter === 'masters'){
-                if (value.position != `Masters`){
-                    // console.log('Pass');
-                        return;
-                }
+            if (filter === 'visitors') {
+                if (value.position != 'Research Engineer' && value.position != 'Postdoc' && value.position != 'Visiting Scholar') { return; }
             }
-            if (filter === 'undergraduate'){
-                if (value.position != `Undergraduate`){
-                    // console.log('Pass');
-                        return;
-                }
-            }                        
-
+            if (filter === 'masters') {
+                if (value.position != 'Masters') { return; }
+            }
+            if (filter === 'undergraduate') {
+                if (value.position != 'Undergraduate') { return; }
+            }
+            if (filter === 'staff') {
+                if (value.position != 'Staff') { return; }
+            }
         }
         counter += 1;
 
-        member_figure = '';
-        if (value.photo != null){
-            member_figure = '<img class="member_image" src="' + value.photo + '" alt="' + value.name + '">';
-        } else {
-            member_figure = '<img class="member_image" src="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22120%22 height=%22120%22%3E%3Crect width=%22120%22 height=%22120%22 fill=%22%23e0e0e0%22/%3E%3C/svg%3E" alt="No photo available for ' + value.name + '">';
+        // Name (linked to homepage when available)
+        var name_html = value.homepage != null
+            ? '<a href="' + value.homepage + '" title="Visit homepage">' + value.name + '</a>'
+            : value.name;
+
+        // Role line: position, optional co-advisor
+        var role_html = value.position || '';
+        if (value.coadvisor != null) {
+            role_html += ', w/ <a href="' + value.coadvisor_homepage + '">' + value.coadvisor + '</a>';
         }
 
-        member_name = '';
-        if (value.homepage != null){
-            member_name = '<a href="' + value.homepage + '" title="Visit homepage">' + value.name + '</a><br>';
-        } else{
-            member_name = value.name  + '<br>';
-        }
-        member_name +=  value.position
-        member_coadvisor = '';
-        if (value.coadvisor != null){
-            member_coadvisor = ', w/ <a href="' + value.coadvisor_homepage + '">' + value.coadvisor + '</a>';
-        }
-        member_fellow = '';
-        if (value.fellow != null && value.name !== 'Young-Jun Lee' && value.name !== 'Seungyeon Jwa'){
-            member_fellow = ', ' + value.fellow + '';
+        // Research interest (shown for students/visitors who have one)
+        var interest_html = '';
+        if (value.interest != null) {
+            interest_html = '<div class="it">' + value.interest + '</div>';
         }
 
-        member_interest = '';
-        if (value.interest != null && (value.position === 'PhD' || value.position === 'Visiting PhD')){
-            member_interest = '<br><i>' + value.interest + '</i>';
+        // Fellowship / status tag
+        var tag_html = '';
+        if (value.fellow != null && value.name !== 'Young-Jun Lee' && value.name !== 'Seungyeon Jwa') {
+            tag_html = '<span class="tg">' + value.fellow + '</span>';
         }
 
-        var decodedVar = '<figure class="member_figure">' + member_figure + '<figcaption class="member_image_caption">' + member_name + member_coadvisor + member_fellow + member_interest + '</figcaption></figure>';
+        var photo_block = member_photo(value, 'ph');
+        var shot = value.homepage != null
+            ? '<a class="shot" href="' + value.homepage + '">' + photo_block + '</a>'
+            : photo_block;
 
+        var card = '<div class="pc">' +
+            shot +
+            '<div class="nm">' + name_html + '</div>' +
+            '<div class="rl">' + role_html + '</div>' +
+            interest_html +
+            tag_html +
+            '</div>';
 
-        decodedText += decodedVar;
-        decodedTextList.push(decodedVar);
+        cards.push(card);
     });
 
-    shuffleArray(decodedTextList);
-   
-    if (counter > 0){
-        // decodedText = '<div class="members_wrapper" style="width:100%">' + decodedText + '</div>';
-        decodedText = '<div class="members_wrapper">' + decodedTextList.join('') + '</div>';
-        // decodedText = decodedText ;
+    shuffleArray(cards);
 
+    var div_tag = 'members';
+    if (filter != null) { div_tag += '_' + filter; }
+    if (counter > 0) {
+        $('#' + div_tag).append(cards.join(''));
     }
-
-    div_tag = 'members';
-    if (filter != null){
-        div_tag += '_' + filter;
-    }
-    // console.log('Filter: ' + div_tag + decodedText);
-
-    $('#'+div_tag).append(decodedText);
 }
 
 
 
-function render_alumni(elements, filter=null){
+function render_alumni(elements, filter = null) {
 
-    var decodedText = '';
     var counter = 0;
-    // console.log(elements);
     var filter_second = null;
 
-    
-    const myArry = filter.split("_");
-    if (myArry.length > 1){
-        filter_second = myArry[1];
-    }
+    var myArry = (filter || '').split('_');
+    if (myArry.length > 1) { filter_second = myArry[1]; }
+
+    var feat_cards = [];   // doctoral alumni
+    var list_cells = [];   // masters / undergraduate alumni
 
     $.each(elements, function (index, value) {
-    //    console.log(value.name + ' / ' + value.position + ' : ' + filter + ' / ' + index + ' : ' + counter);
 
-        // filters
-        if (filter != null){
-            if (filter === 'alumni' | filter === 'alumni_phd' | filter === 'alumni_masters' | filter === 'alumni_undergraduate' | filter === 'alumni_mastersundergraduate'){
-                if (value.current === true){
-                        // console.log('Pass');
-                        return;
-                }
-                if (filter === 'alumni_mastersundergraduate'){
-                    if (value.position !== 'Masters' && value.position !== 'Undergraduate'){
-                        return;
-                    }
-                } else if (filter_second != null && value.position != null){
-                    if (! value.position.toString().toLowerCase().includes(filter_second)){
-                        // console.log('%%%%% Filtering:',value.position.toString().toLowerCase(), filter_second);
-                        return;
-                    }else{
-                        // console.log(value.position, filter_second, value);
-                    }
+        if (filter != null) {
+            if (filter === 'alumni' || filter === 'alumni_phd' || filter === 'alumni_masters' || filter === 'alumni_undergraduate' || filter === 'alumni_mastersundergraduate') {
+                if (value.current === true) { return; }
+                if (filter === 'alumni_mastersundergraduate') {
+                    if (value.position !== 'Masters' && value.position !== 'Undergraduate') { return; }
+                } else if (filter_second != null && value.position != null) {
+                    if (!value.position.toString().toLowerCase().includes(filter_second)) { return; }
                 }
             }
         }
         counter += 1;
 
-        member_name = value.name;
-        // if (value.homepage != null){
-        member_name = '<a href="' + value.homepage + '">' + value.name + '</a>';
-        // } 
-        
-        member_description = '';
-        if (value.description != null){
-            member_description = ' (' + value.description + ')';
-        }
+        var name_html = value.homepage != null
+            ? '<a href="' + value.homepage + '">' + value.name + '</a>'
+            : value.name;
 
-        member_next_position = '';
-        if (value.next_position != null){
-            member_next_position = value.next_position ;
-        }else{
-            member_next_position = '';
-        }
-
-        var decodedVar = null;
-
-        // PhD alumni format - one per row with left column (image + name) and right column (next position + description)
-        if (filter === 'alumni_phd'){
-            member_figure = '';
-            if (value.photo != null){
-                member_figure = '<img class="member_image" src="' + value.photo + '" alt="' + value.name + '" style="width: 100px; height: 100px;">';
+        // Doctoral alumni: featured card with portrait, next role, and a note.
+        if (filter === 'alumni_phd') {
+            var next_html = '';
+            if (value.next_position != null) {
+                next_html = '<div class="nx">→ ' + value.next_position + '</div>';
+            }
+            var note_html = '';
+            if (value.note != null) {
+                note_html = '<div class="nt">' + value.note + '</div>';
+            } else if (value.description != null) {
+                note_html = '<div class="nt">' + value.description + '</div>';
             }
 
-            var phd_name_link = '<a href="' + value.homepage + '">' + value.name + '</a>';
-            
-            // Left column: photo and name
-            var left_column = '<div style="flex: 0 0 150px; display: flex; flex-direction: column; align-items: center; gap: 10px;">' + 
-                              member_figure + 
-                              '<div style="text-align: center;">' + phd_name_link + '</div>' +
-                              '</div>';
-
-            // Right column: next position and description/interest
-            var right_column_content = '';
-            if (value.note != null){
-                right_column_content += value.note;
-            }
-
-            var right_column = '<div style="flex: 1; padding-left: 20px; display: flex; align-items: center;">' + right_column_content + '</div>';
-
-            decodedVar = '<div style="display: flex; margin-bottom: 20px; border-bottom: 1px solid #ddd; padding-bottom: 20px;">' + 
-                         left_column + 
-                         right_column + 
-                         '</div>';
+            feat_cards.push(
+                '<div class="af">' +
+                    member_photo(value, 'ph') +
+                    '<div>' +
+                        '<div class="nm">' + name_html + '</div>' +
+                        next_html +
+                        note_html +
+                    '</div>' +
+                '</div>'
+            );
         }
-        // Condensed layout for masters and undergraduate alumni
-        else if (filter === 'alumni_masters' || filter === 'alumni_undergraduate' || filter === 'alumni_mastersundergraduate'){
-            if (member_next_position == ''){
-                decodedVar = '<span style="margin-right: 15px; display: inline-block;">' + member_name + '</span>';
-            } else{
-                decodedVar = '<span style="margin-right: 15px; display: inline-block;">' + member_name+ ' (' + member_next_position + ')</span>';
-            }
-        } else{
-            if (filter_second == null || member_next_position == ''){
-                decodedVar = '<div class="col-3" style="text-align: center;">' + member_name +  '</div>';
-            } else{
-                decodedVar = '<div class="col-3" style="text-align: center;">' + member_name+ '<br> (' + member_next_position + ')</div>';
-            }
+        // Masters & undergraduate alumni: compact cell.
+        else {
+            var nx = (value.next_position != null && value.next_position !== '')
+                ? '<br><span class="nx">' + value.next_position + '</span>'
+                : '';
+            list_cells.push('<div class="acell">' + name_html + nx + '</div>');
         }
-
-        // console.log(decodedVar, value.position, filter_second);
-
-        decodedText += decodedVar;
-
     });
-    // console.log(decodedText,counter);
-   
-    if (counter > 0){
-        // decodedText =  decodedText ;
-        // Use condensed wrapper for masters and undergraduate alumni
-        if (filter === 'alumni_masters' || filter === 'alumni_undergraduate' || filter === 'alumni_mastersundergraduate'){
-            decodedText = '<div class="members_wrapper_condensed" style="width:100%; display: flex; flex-wrap: wrap; gap: 5px;">' + decodedText + '</div>';
-        } else if (filter === 'alumni_phd'){
-            // PhD alumni: full-width rows with left/right layout
-            decodedText = '<div style="width:100%;">' + decodedText + '</div>';
-        } else{
-            decodedText = '<div class="members_wrapper row" style="width:100%">' + decodedText + '</div>';
+
+    if (counter > 0) {
+        var div_tag = 'members' + (filter != null ? '_' + filter : '');
+        if (filter === 'alumni_phd') {
+            $('#' + div_tag).append(feat_cards.join(''));
+        } else {
+            $('#' + div_tag).append(list_cells.join(''));
         }
-
     }
-
-    div_tag = 'members';
-    if (filter != null){
-        div_tag += '_' + filter;
-        
-    }
-
-
-    // console.log(div_tag,'==========================', decodedText);
-    $('#'+div_tag).append(decodedText);
 }
-
-
-
-
-
-
-

--- a/js/myscript_footer.js
+++ b/js/myscript_footer.js
@@ -3,48 +3,28 @@ function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', 'UA-166307709-1');
 
+// ---- Publications (chronological, newest first) ----
 var json_pub_url = 'https://dykang.github.io/assets/publication_with_abstract.json';
-$.getJSON(json_pub_url, function foo(result) { render_pub(result, filter=2026); });
-$.getJSON(json_pub_url, function foo(result) { render_pub(result, filter=2025); });
-$.getJSON(json_pub_url, function foo(result) { render_pub(result, filter=2024); });
-$.getJSON(json_pub_url, function foo(result) { render_pub(result, filter=2023); });
-$.getJSON(json_pub_url, function foo(result) { render_pub(result, filter=2022); });
-$.getJSON(json_pub_url, function foo(result) { render_pub(result, filter=2021); });
+$.getJSON(json_pub_url, function (result) { render_pub(result, filter=2026); });
+$.getJSON(json_pub_url, function (result) { render_pub(result, filter=2025); });
+$.getJSON(json_pub_url, function (result) { render_pub(result, filter=2024); });
+$.getJSON(json_pub_url, function (result) { render_pub(result, filter=2023); });
+$.getJSON(json_pub_url, function (result) { render_pub(result, filter=2022); });
+$.getJSON(json_pub_url, function (result) { render_pub(result, filter=2021); });
 
+// ---- News ----
 var json_news_url = 'https://minnesotanlp.github.io/assets/news.json';
-// var json_news_url = '../assets/news.json'; #for testing locally
-$.getJSON(json_news_url, function foo(result) { render_news(result); });
+// var json_news_url = '../assets/news.json'; // for testing locally
+$.getJSON(json_news_url, function (result) { render_news(result); });
 
+// ---- Current members ----
 var json_member_url = 'https://dykang.github.io/assets/members.json';
-$.getJSON(json_member_url, function foo(result) { render_member(result, filter='faculty'); });
-$.getJSON(json_member_url, function foo(result) { render_member(result, filter='visitors'); });
-$.getJSON(json_member_url, function foo(result) { render_member(result, filter='phd'); });
-$.getJSON(json_member_url, function foo(result) { render_member(result, filter='mastersundergraduate'); });
-$.getJSON(json_member_url, function foo(result) { render_member(result, filter='staff'); });
+$.getJSON(json_member_url, function (result) { render_member(result, filter='faculty'); });
+$.getJSON(json_member_url, function (result) { render_member(result, filter='visitors'); });
+$.getJSON(json_member_url, function (result) { render_member(result, filter='phd'); });
+$.getJSON(json_member_url, function (result) { render_member(result, filter='mastersundergraduate'); });
 
+// ---- Alumni ----
 var json_alumni_url = 'https://dykang.github.io/assets/alumni.json';
-$.getJSON(json_alumni_url, function foo(result) { render_alumni(result, filter='alumni'); });
-$.getJSON(json_alumni_url, function foo(result) { render_alumni(result, filter='alumni_phd'); });
-$.getJSON(json_alumni_url, function foo(result) { render_alumni(result, filter='alumni_mastersundergraduate'); });
-
-
-$(function () {
-    $('span.alumni').click(function () {
-        $('#datalist_alumni li:hidden').slice(0, 5).show();
-        if ($('#datalist_alumni li').length == $('#datalist_alumni li:visible').length) {
-            $('span.alumni').hide();
-        }
-    });
-});
-
-
-function show_alumni() {
-    var x = document.getElementById("datalist_alumni");
-    if (x.style.display === "block") {
-      x.style.display = "none";
-    } else {
-      x.style.display = "block";
-    }
-  }
-
-
+$.getJSON(json_alumni_url, function (result) { render_alumni(result, filter='alumni_phd'); });
+$.getJSON(json_alumni_url, function (result) { render_alumni(result, filter='alumni_mastersundergraduate'); });

--- a/js/news_loader.js
+++ b/js/news_loader.js
@@ -1,13 +1,13 @@
-function render_news(elements=null, filter=null){
+function render_news(elements = null, filter = null) {
     var decoded_text = '';
     var counter = 0;
-    
-    // Category colors mapping
+
+    // Category accent colors (kept from the previous design for continuity).
     const categoryColors = {
-        'defense': '#d32f2f',
+        'defense': '#9C4423',
         'award': '#1976d2',
         'milestone': '#388e3c',
-        'announcement': '#f57c00',
+        'announcement': '#BC5630',
         'recruitment': '#7b1fa2',
         'internship': '#0097a7',
         'graduation': '#5e35b1',
@@ -16,45 +16,34 @@ function render_news(elements=null, filter=null){
     };
 
     $.each(elements, function (index, value) {
-        if (counter >= 5) return false;
-        counter += 1;
+        if (counter >= 8) return false;
 
-        if (value.date != null && value.description != null){
-            // Get category and importance
+        if (value.date != null && value.description != null) {
+            counter += 1;
+
             var category = value.category || 'announcement';
             var importance = value.importance || 'normal';
-            var categoryColor = categoryColors[category] || '#666';
-            
-            // Create category badge
-            var categoryBadge = '<span class="news-badge" style="background-color: ' + categoryColor + ';">' + 
-                               category.charAt(0).toUpperCase() + category.slice(1) + '</span>';
-            
-            // Highlight important news with border
-            var importanceClass = importance === 'high' ? 'news-card-important' : '';
-            
-            // Build card
-            var decodedVar = '<div class="news-card ' + importanceClass + '">' +
-                            '<div class="news-header">' +
-                            categoryBadge +
-                            '<span class="news-date">' + value.date + '</span>' +
-                            '</div>' +
-                            '<div class="news-content">' + value.description + '</div>' +
-                            '</div>';
-        }
+            var categoryColor = categoryColors[category] || '#8A7765';
 
-        decoded_text += decodedVar;
+            var categoryBadge = '<span class="news-badge" style="background-color: ' + categoryColor + ';">' +
+                category.charAt(0).toUpperCase() + category.slice(1) + '</span>';
+
+            var importanceClass = importance === 'high' ? 'news-card-important' : '';
+
+            decoded_text +=
+                '<div class="news-card ' + importanceClass + '">' +
+                    '<div class="news-header">' +
+                        '<span class="news-date">' + value.date + '</span>' +
+                        categoryBadge +
+                    '</div>' +
+                    '<div class="news-content">' + value.description + '</div>' +
+                '</div>';
+        }
     });
 
-    if (counter > 0){
+    if (counter > 0) {
         decoded_text = '<div class="news-container">' + decoded_text + '</div>';
     }
 
     $('#items_news').append(decoded_text);
 }
-
-
-
-
-
-
-

--- a/js/pub_loader.js
+++ b/js/pub_loader.js
@@ -1,96 +1,63 @@
 
-function render_pub(elements, filter=null){
-    // var elements = result;
-    // console.log(elements);
+function render_pub(elements, filter = null) {
 
-
-
-    var decodedText = '';
+    var items = [];
     var counter = 0;
 
     $.each(elements, function (index, value) {
-        // decoder.html(value.title);
-        // console.log(value);
-        // decodedText += decoder.text();
-        // console.log(value.year + ' / ' + value.topic + ' : ' + filter + ' / ' + index + ' : ' + counter);
 
-        if (filter != null){
-            if (value.year != filter && value.topic != filter){
-                // console.log('Pass');
-                return;
-            }
+        if (filter != null) {
+            if (value.year != filter && value.topic != filter) { return; }
         }
-        
-
         counter += 1;
 
-        venue_text = '';
-        if (value.venue != null){
-            venue_text = '<span class="venue"><a href="' + value.venue_link + '">' + value.venue + ' ' + value.year + '</a>';
-            if (value.note != null){
-                venue_text += ' (' + '<span class="highlight">' + value.note + '</span>)'
+        // Venue line (italic) with optional highlight note.
+        var venue_text = '';
+        if (value.venue != null) {
+            venue_text = '<span class="venue"><a href="' + value.venue_link + '">' + value.venue + ' ' + value.year + '</a></span>';
+            if (value.note != null) {
+                venue_text += ' <span class="nt">' + value.note + '</span>';
             }
-            venue_text += ' / ' + '</span>';
-        }
-        paper_text = 'Paper';
-        if (value.paper != null){
-            paper_text = '<span class="tag"> <a href="' + value.paper + '">Paper</a></span>';
-        }        
-        code_text = '';
-        if (value.code != null){
-            code_text = '<span class="tag"> / <a href="' + value.code + '">Code</a></span>';
-        }
-        data_text = '';
-        if (value.data != null){
-            data_text = '<span class="tag"> / <a href="' + value.data + '">Data</a></span>';
-        }
-        demo_text = '';
-        if (value.demo != null){
-            demo_text = '<span class="tag"> / <a href="' + value.demo + '">Demo</a></span>';
-        }        
-        project_text = '';
-        if (value.project != null){
-            project_text = '<span class="tag"> / <a href="' + value.project + '">Project</a></span>';
-        }
-        tweet_text = '';
-        if (value.tweet != null){
-            tweet_text = '<span class="tag"> / <a href="' + value.tweet + '">Tweet</a></span>';
-        }
-        appendix_text = '';
-        if (value.appendix != null){
-            appendix_text = '<span class="tag"> / <a href="' + value.appendix + '">Appendix</a></span>';
         }
 
-        var decodedVar = '<li><div class="publication pub-card"><div class="text"> \
-            <div class="title pub-title">' + value.title + '</div> \
-            <div class="authors pub-authors">' + value.author + '</div> \
-            <div class="pub-links">' + venue_text + paper_text + code_text + data_text + demo_text + project_text + tweet_text + appendix_text + 
-            '</div></div></div></li>';
+        // Resource links (Paper / Code / Data / Demo / Project / Tweet / Appendix).
+        var links = [];
+        if (value.paper != null)    { links.push('<a href="' + value.paper + '">Paper</a>'); }
+        if (value.code != null)     { links.push('<a href="' + value.code + '">Code</a>'); }
+        if (value.data != null)     { links.push('<a href="' + value.data + '">Data</a>'); }
+        if (value.demo != null)     { links.push('<a href="' + value.demo + '">Demo</a>'); }
+        if (value.project != null)  { links.push('<a href="' + value.project + '">Project</a>'); }
+        if (value.tweet != null)    { links.push('<a href="' + value.tweet + '">Tweet</a>'); }
+        if (value.appendix != null) { links.push('<a href="' + value.appendix + '">Appendix</a>'); }
+        var links_text = links.length ? '<span class="tag"> &middot; ' + links.join(' · ') + '</span>' : '';
 
+        // Title links to the paper (or the next best available URL).
+        var title_url = value.paper || value.venue_link || value.project || null;
+        var title_html = title_url != null
+            ? '<a href="' + title_url + '">' + value.title + '</a>'
+            : value.title;
 
-        decodedText += decodedVar;
-
+        items.push(
+            '<div class="pit">' +
+                '<div class="t">' + title_html + '</div>' +
+                '<div class="a">' + value.author + '</div>' +
+                '<div class="v">' + venue_text + links_text + '</div>' +
+            '</div>'
+        );
     });
-   
-    if (counter > 0){
-        decodedText = '<ul class="pub-list">' + decodedText + '</ul>';
-    }
 
-    div_tag = 'publication';
-    if (filter != null){
-        div_tag += '_' + filter;
-        if (typeof filter === "number"){
-            decodedText = '<div class="text anchor"><h4 class="pub-year-header">' + filter + '</h4>' + decodedText + '</div>'
-        }else{
-            decodedText = '<div class="text anchor">' + decodedText + '</div>'
+    if (counter > 0) {
+        var div_tag = 'publication';
+        var block = items.join('');
+        if (filter != null) {
+            div_tag += '_' + filter;
+            if (typeof filter === 'number') {
+                block = '<div class="pblock">' +
+                            '<div class="pyr">' + filter + '</div>' +
+                            '<div class="pitems">' + block + '</div>' +
+                        '</div>';
+            }
         }
-        
+        $('#' + div_tag).append(block);
     }
-    
-    // console.log(div_tag);
-
-    $('#'+div_tag).append(decodedText);
 }
-
-
-


### PR DESCRIPTION
## Summary

Redesigns the group homepage using the **"Field Notes"** direction (03) from the attached design file — the warm, photo-forward, magazine-style treatment.

**Look & feel**
- Cream / clay (terracotta) / olive palette, set in the **Spectral** humanist serif
- Cover-style hero: cycling group photo with an `Est. 2021` stamp and caption tab
- Sticky translucent nav with a mobile menu
- "Five questions we keep returning to" research-thrusts grid
- Rounded 4:5 portrait people cards (initials fallback when a photo is missing)
- Dedicated **Lab Life** photo gallery
- Year-grouped publications with sticky year columns and resource links
- News as a dated, badged feed; a **Funding & partners** logo strip

**Every existing section is preserved**: welcome, people (faculty / visitors / PhD / masters & undergrad + alumni), publications, news, lab culture, and funding.

## Data stays live
Per the chosen approach, content is **not** hardcoded. Members, alumni, publications, and news continue to load from the existing JSON endpoints (`dykang.github.io/assets/*` and `minnesotanlp.github.io/assets/news.json`). The loader render functions were rewritten to emit the new markup while keeping the existing field names and filter logic, so the page keeps auto-updating.

## Implementation notes
- `index.html` — new self-contained layout + inline theme; replaces the Bootstrap / Font Awesome / Academicons stack on the homepage. Adds skip link, responsive breakpoints, mobile nav, and back-to-top.
- `js/member_loader.js` — `render_member` / `render_alumni` now emit `.pc` people cards and `.af` / `.acell` alumni; preserves position filters, co-advisor, interest, and fellowship-tag rules.
- `js/pub_loader.js` — `render_pub` emits `.pblock` year groups with title→paper links and Paper/Code/Data/etc. tags.
- `js/news_loader.js` — `render_news` emits themed `.news-card` rows (shows up to 8).
- `js/myscript_footer.js` — trimmed to the live-data fetches + analytics.
- `js/sponsor_loader.js` — unchanged; its output is restyled for the new funding strip.

The orphaned legacy scripts/styles (`slider.js`, `widget.js`, `mystyle.css`, etc.) are left in place since other pages may reference them.

## Verification
- CDN/live JSON are blocked in the build sandbox, so rendering was verified with a Node harness (a minimal jQuery stub) running the **real** loader files against fixtures using the live field names — members, alumni (PhD + masters/undergrad), publications, and news all produce correct markup. CSS is adapted verbatim from the working mockup.
- ⚠️ Recommend a quick visual smoke test on GitHub Pages (where the live JSON resolves) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013wdetZNWkvBAqeYi4aJAMV)_